### PR TITLE
update start cmd, no need wait after start command

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -71,8 +71,6 @@ func start(c *cobra.Command, args []string) {
 		}
 	}
 
-	cmd.Wait()
-
 	pinfo, _ := getProcessByPid(pid)
 	fmt.Println(pinfo)
 	if pinfo == "" {


### PR DESCRIPTION
Start starts the specified command but does not wait for it to complete.

after rigger start. it will exec cmd on background.